### PR TITLE
Production issue - Name with single quote breaks Report Filter UI

### DIFF
--- a/webapps/bizflow/solutions/cms/index.jsp
+++ b/webapps/bizflow/solutions/cms/index.jsp
@@ -76,8 +76,10 @@ private String getCMSUserGroups() throws Exception
             
             String grpid = rs.getString("grpid");
             String grpname = rs.getString("grpname");
+            grpname = grpname.replaceAll("'","\\\\'");
             String memberid = rs.getString("memberid");
             String name = rs.getString("name");
+            name = name.replaceAll("'","\\\\'");
 
             sb.append("{");
             sb.append("\"grpid\":\"").append(grpid).append("\",");


### PR DESCRIPTION
Kevin,
This commit fixes the production issue on report filter UI.

The root cause of this issue is that single quote in the name breaks JSON object and it caused syntax error in index.jsp. This code will escape the single quote in the name.

Regards,
Peter