### PR TITLE
Fix for Section 508 issues on report filter UI

### DIFF
--- a/webapps/bizflow/solutions/cms/features/reportFilter/report-filter-erlr.html
+++ b/webapps/bizflow/solutions/cms/features/reportFilter/report-filter-erlr.html
@@ -33,6 +33,10 @@
     div.button-section {
         margin-top: 5px;
     }
+    /* Fix for Selectize bug - Show only 4px on input tag */
+    .selectize-input.not-full > input {
+        width: 100% !important;
+    }    
 </style>
 
 <div role="dialog" id="reportFilter" ng-form="fReportSection">

--- a/webapps/bizflow/solutions/cms/features/reportFilter/report-filter-erlr.js
+++ b/webapps/bizflow/solutions/cms/features/reportFilter/report-filter-erlr.js
@@ -168,6 +168,10 @@
             if (vm.selected.finalActions.length == 0) {
                 vm.selected.finalAction = 'All';
             }
+
+            setTimeout(function() {
+                $('#finalActionSelect').focus();
+            }, 0);            
         }
 
         vm.addCaseCategory = function(value) {
@@ -213,6 +217,9 @@
             if (vm.selected.caseCategories.length == 0) {
                 vm.selected.caseCategory = 'All';
             }
+            setTimeout(function() {
+                $('#caseCategorySelect').focus();
+            }, 0);
         }        
 
         vm.addStatus = function(value) {
@@ -259,6 +266,9 @@
             if (vm.selected.statusList.length == 0) {
                 vm.selected.status = 'All';
             }
+            setTimeout(function() {
+                $('#caseStatusSelect').focus();
+            }, 0);
         }        
 
         vm.categories = [];
@@ -710,12 +720,12 @@
                 'minlength': 'Enter a minimum of three characters for the administrative code'
             },
             'dateRCompletedFromInput': {
-                'required': 'Type the from date in the format MM/DD/YYYY for the request date range',
-                'date': 'Type the date in the format: MM/DD/YYYY'
+                'required': 'Type the from date in the format "MM/DD/YYYY" for the request date range',
+                'date': 'Type the date in the format: MM/DD/YYYY.'
             },
             'dateRCompletedToInput': {
-                'required': 'Type the end date in the format MM/DD/YYYY for the request date range',
-                'date': 'Type the date in the format: MM/DD/YYYY'
+                'required': 'Type the end date in the format "MM/DD/YYYY" for the request date range',
+                'date': 'Type the date in the format: MM/DD/YYYY.'
             },
             'dayType': {
                 'required': 'Select Business or Calendar Days'

--- a/webapps/bizflow/solutions/cms/features/reportFilter/report-filter.html
+++ b/webapps/bizflow/solutions/cms/features/reportFilter/report-filter.html
@@ -15,6 +15,10 @@
         margin: -10px 0px 0px 12px;
         /* padding: -10px 12px 6px 12px; */
     } 
+    /* Fix for Selectize bug - Show only 4px on input tag */
+    .selectize-input.not-full > input {
+        width: 100% !important;
+    }    
      
 </style>
 

--- a/webapps/bizflow/solutions/cms/features/reportFilter/report-filter.js
+++ b/webapps/bizflow/solutions/cms/features/reportFilter/report-filter.js
@@ -544,12 +544,12 @@
                 'minlength': 'Enter a minimum of three characters for the administrative code'
             },
             'dateRCompletedFromInput': {
-                'required': 'Type the from date in the format MM/DD/YYYY for the request date range',
-                'date': 'Type the date in the format: MM/DD/YYYY'
+                'required': 'Type the from date in the format "MM/DD/YYYY" for the request date range',
+                'date': 'Type the date in the format: MM/DD/YYYY.'
             },
             'dateRCompletedToInput': {
-                'required': 'Type the end date in the format MM/DD/YYYY for the request date range',
-                'date': 'Type the date in the format: MM/DD/YYYY'
+                'required': 'Type the end date in the format "MM/DD/YYYY" for the request date range',
+                'date': 'Type the date in the format: MM/DD/YYYY.'
             },
             'dayType': {
                 'required': 'Select Business or Calendar Days'

--- a/webapps/bizflow/solutions/cms/incentives/reportFilter/report-filter.html
+++ b/webapps/bizflow/solutions/cms/incentives/reportFilter/report-filter.html
@@ -37,6 +37,11 @@
         margin-left: 3px;
         margin-top: -3px;
     }    
+
+    /* Fix for Selectize bug - Show only 4px on input tag */
+    .selectize-input.not-full > input {
+        width: 100% !important;
+    }
 </style>
 
 <div role="dialog" id="reportFilter" ng-form="fReportSection">

--- a/webapps/bizflow/solutions/cms/incentives/reportFilter/report-filter.js
+++ b/webapps/bizflow/solutions/cms/incentives/reportFilter/report-filter.js
@@ -75,7 +75,7 @@
         // Default Values
         vm.orgSelected = {
             component: '',
-            incentiveType: 'All',
+            incentiveType: null,
             incentiveTypes: [],
             adminCode: '',
             includeSubOrg: 'Yes',
@@ -295,7 +295,7 @@
             }
 
             if (vm.selected.hrSpecialist) {
-                url = url + '&HRS_ID=' + (vm.isSection508User == true ? vm.selected.hrSpecialist.memberid : vm.selected.hrSpecialist); // HR Specialist
+                url = url + '&HRS_ID=' + vm.selected.hrSpecialist.memberid; // HR Specialist
             }
 
             if (vm.selected.incentiveType) {
@@ -453,12 +453,12 @@
                 'minlength': 'Enter a minimum of three characters for the administrative code'
             },
             'dateRCompletedFromInput': {
-                'required': 'Type the from date in the format MM/DD/YYYY for the request date range',
-                'date': 'Type the date in the format: MM/DD/YYYY'
+                'required': 'Type the from date in the format "MM/DD/YYYY" for the request date range',
+                'date': 'Type the date in the format: MM/DD/YYYY.'
             },
             'dateRCompletedToInput': {
-                'required': 'Type the end date in the format MM/DD/YYYY for the request date range',
-                'date': 'Type the date in the format: MM/DD/YYYY'
+                'required': 'Type the end date in the format "MM/DD/YYYY" for the request date range',
+                'date': 'Type the date in the format: MM/DD/YYYY.'
             },
             'dayType': {
                 'required': 'Select Business or Calendar Days'
@@ -522,6 +522,9 @@
             if (vm.selected.incentiveTypes.length == 0) {
                 vm.selected.incentiveType = 'All';
             }
+            setTimeout(function() {
+                $('#selectIncentiveType').focus();
+            }, 0);                 
         }
 
         vm.getIncentiveTypeLabel = function(value) {
@@ -568,10 +571,13 @@
             vm.dayTypes = vm.getSelectizeOptions(vm._dayTypes); //#290605 - Business and Calendar Days filter 
 
             if (vm.isSection508User == true) {
+                vm.selected.incentiveType = 'All';
                 // #selectComponent is not processed yet. So, use setTimeout.
                 setTimeout(function() {
                     $('#selectComponent').on('keydown', vm.onKeyDownComponent);
                 }, 0);
+            } else {
+                vm.selected.incentiveType = null;
             }
 
             setTimeout(function() {


### PR DESCRIPTION
Hi Moderator,

This PR includes following changes for Section 508 issues on report filter UI.

1. In section 508 mode, UI uses plain dropdown instead of selectize.
2. In section 508 mode, UI uses Bootstrap Typeahead instead of selectize if typeahead feature is required.
3. In section 508 mode, UI adds additional keyboard event listener to capture TAB event on plain dropdown so that UI can adjust focus movement.

Regards,
Peter